### PR TITLE
Sidebarコンポーネントの表示内容を修正し、長いテキストを省略表示するように変更

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -53,15 +53,20 @@ const Sidebar = () => {
     return (
       <div className="overflow-y-auto">
         <ul className="list-none w-full flex flex-col-reverse">
-          {history.map((item, index) => (
-            <li
-              key={index}
-              className="py-2 px-4 m-2 max-h-32 overflow-hidden text-white text-xs text-left border border-white cursor-pointer rounded"
-              onClick={() => handleClick(index)}
-            >
-              {item.input}
-            </li>
-          ))}
+          {history.map((item, index) => {
+            const maxlength = 200
+            const leader = item.input.length > maxlength ? '...' : ''
+            return (
+              <li
+                key={index}
+                className="py-2 px-4 m-2 max-h-32 overflow-hidden text-white text-xs text-left border border-white cursor-pointer rounded"
+                onClick={() => handleClick(index)}
+              >
+                {item.input.slice(0, maxlength)}
+                {leader}
+              </li>
+            )
+          })}
         </ul>
       </div>
     )


### PR DESCRIPTION
components/Sidebar.tsx
- history配列の要素を表示する部分を修正
- history配列の各要素のinputプロパティの文字列が一定の長さを超える場合は、省略表示するように変更
- maxlength変数を定義し、省略表示の閾値として使用
- leader変数を定義し、省略表示時に表示する"..."を追加
- item.inputの一部をmaxlengthまでの文字列とleaderを結合して表示